### PR TITLE
Add missing word

### DIFF
--- a/source/acknowledgements.rst
+++ b/source/acknowledgements.rst
@@ -1,6 +1,6 @@
 **Acknowledgements**
 
-The devicetree.org Technical Steering Committee would like
+The devicetree.org Technical Steering Committee would like to
 thank the many individuals and companies that contributed to the
 development this specification through writing, technical discussions
 and reviews.


### PR DESCRIPTION
Signed-off-by: Manuel Groß <mgr@nordkrater.de>