### PR TITLE
Record i2c-mux and power-monitor names

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -252,6 +252,7 @@ name should be one of the following choices:
    * pmu
    * port
    * ports
+   * power-monitor
    * pwm
    * regulator
    * reset-controller

--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -219,6 +219,7 @@ name should be one of the following choices:
    * gyrometer
    * hdmi
    * i2c
+   * i2c-mux
    * ide
    * interrupt-controller
    * isa


### PR DESCRIPTION
This PR is based on my talk with Rob where i2c-mux should be used but it is not listed. 
And there is no standard name for ina226 chip that's why I choose power-monitor. 