### PR TITLE
Remove duplicated node name recommendation

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -199,7 +199,6 @@ name should be one of the following choices:
    * clock
    * clock-controller
    * compact-flash
-   * can
    * cpu
    * cpus
    * crypto


### PR DESCRIPTION
Node name *can* was mentioned twice in the list, removed one (and preserving alphabetical order).