### PR TITLE
Document the reserved status

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -573,6 +573,10 @@ Description:
                   Refer to the device binding for details on what disabled means
                   for a given device.
    -------------- --------------------------------------------------------------
+   ``"reserved"`` Indicates that the device is operational, but should not be
+                  used. Typically this is used for devices that are controlled
+                  by another software component, such as platform firmware.
+   -------------- --------------------------------------------------------------
    ``"fail"``     Indicates that the device is not operational. A serious error
                   was detected in the device, and it is unlikely to become
                   operational without repair.


### PR DESCRIPTION
We use this on Bare metal Power 8/9 systems to mark devices that
are used by the OPAL firmware rather than being available to the
operating system.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>