### PR TITLE
Add air-pollution-sensor to the recommended node names

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -187,6 +187,7 @@ name should be one of the following choices:
 
    * adc
    * accelerometer
+   * air-pollution-sensor
    * atm
    * audio-codec
    * audio-controller


### PR DESCRIPTION
We have had drivers for these type of sensors in kernel for some time
already hence add a new node name to the list for completeness.

Signed-off-by: Tomasz Duszynski <tduszyns@gmail.com>