### PR TITLE
Add lora as a standard node name

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -235,6 +235,7 @@ name should be one of the following choices:
    * leds
    * led-controller
    * light-sensor
+   * lora
    * magnetometer
    * mailbox
    * mdio


### PR DESCRIPTION
LoRa (Long Range) is a wireless communication technology operates in the
Sub-Gigahertz spectrum. LoRa usually implies to the radio which acts as a
transceiver. Hence, add it as a standard node name.

We have these devices in Zephyr which uses devicetree.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>