### PR TITLE
Add co2-sensor to the recommended node names

### DIFF
--- a/source/devicetree-basics.rst
+++ b/source/devicetree-basics.rst
@@ -200,6 +200,7 @@ name should be one of the following choices:
    * charger
    * clock
    * clock-controller
+   * co2-sensor
    * compact-flash
    * cpu
    * cpus


### PR DESCRIPTION
co2-sensor node name has recently appeared in one of binding files hence
should be documented here as well for completeness.

Signed-off-by: Tomasz Duszynski <tomasz.duszynski@octakon.com>