### PR TITLE
Document valid node name character set

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -129,6 +129,8 @@ of characters in :numref:`node-name-characters`.
    ``.``     period
    ``_``     underscore
    ``+``     plus sign
+   ``?``     question mark
+   ``#``     hash
    ``-``     dash
    ========= ================
 


### PR DESCRIPTION
The DT compiler (dtc) supports the same character set for node name as
it does for property name.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>