### PR TITLE
simple-bus: Add nonposted-mmio property

### DIFF
--- a/source/chapter4-device-bindings.rst
+++ b/source/chapter4-device-bindings.rst
@@ -437,5 +437,8 @@ represented as a node with a compatible value of "simple-bus".
                                   array>``              parent address to child address spaces (see
                                                         :numref:`sect-standard-properties-ranges`,
                                                         ranges).
+   ``nonposted-mmio``       O     ``<empty>``           Specifies that direct children of this bus
+                                                        should use non-posted memory accesses (i.e. a
+                                                        non-posted mapping mode) for MMIO ranges.
    Usage legend: R=Required, O=Optional, OR=Optional but Recommended, SD=See Definition
    ====================================================================================================


### PR DESCRIPTION
This property indicates that nodes which are direct children of this bus
shall use non-posted (i.e. no early return) MMIO mapping modes when
mapping MMIO registers. This is a requirement that can be imposed by the
bus on otherwise generic devices.

Signed-off-by: Hector Martin <marcan@marcan.st>