### PR TITLE
Add more restrictions on compatible strings

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -484,6 +484,10 @@ Description:
    (such as a stock ticker symbol), and ``model`` specifies the model
    number.
 
+   The compatible string should consist only of lowercase letters, digits
+   and dashes. A single comma is typically only used following a vendor
+   prefix. Underscores should not be used.
+
 Example:
 
    ``compatible = "fsl,mpc8641", "ns16550";``


### PR DESCRIPTION
Mostly we use lower case and we try to avoid underscores. Add a note
about this.

I believe this is just writing down the existing conventions. I have not
gone as far as using a character table (as with aliases) or specifying a
maximum length.

(this was reference at https://github.com/zephyrproject-rtos/zephyr/issues/29689#issuecomment-720533574 )

Signed-off-by: Simon Glass <sjg@chromium.org>