### PR TITLE
Add note about the initial character in a compatible

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -484,9 +484,9 @@ Description:
    (such as a stock ticker symbol), and ``model`` specifies the model
    number.
 
-   The compatible string should consist only of lowercase letters, digits
-   and dashes. A single comma is typically only used following a vendor
-   prefix. Underscores should not be used.
+   The compatible string should consist only of lowercase letters, digits and
+   dashes, and should start with a letter. A single comma is typically only
+   used following a vendor prefix. Underscores should not be used.
 
 Example:
 


### PR DESCRIPTION
Commit 05a34819e5 ("Add more restrictions on compatible strings")
started to add recommendations on the contents of compatible strings.

Add an additional recommendation that compatibles should start with a
letter. In particular, this matches what dt-schema is doing.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>