### PR TITLE
Add new 'chassis-type' root node property

### DIFF
--- a/source/chapter3-devicenodes.rst
+++ b/source/chapter3-devicenodes.rst
@@ -52,6 +52,17 @@ are descendants. The full path to the root node is ``/``.
                                                ``compatible = "fsl,mpc8572ds"``
    ``serial-number``   O     ``<string>``      Specifies a string representing the device's
                                                serial number.
+   ``chassis-type``    OR    ``<string>``      Specifies a string that identifies the form-factor
+                                               of the system. The property value can be one of:
+
+                                               * ``"desktop"``
+                                               * ``"laptop"``
+                                               * ``"convertible"``
+                                               * ``"server"``
+                                               * ``"tablet"``
+                                               * ``"handset"``
+                                               * ``"watch"``
+                                               * ``"embedded"``
    Usage legend: R=Required, O=Optional, OR=Optional but Recommended, SD=See Definition
    ===========================================================================================
 


### PR DESCRIPTION
ACPI-based systems generally provide DMI data allowing userspace software to identify the form-factor of the running system.

Such information can be useful (for example, in order to implement different behavior on a desktop and on a smartphone) but is not readily available on DT-based systems.

This patch proposes adding a new optional property to the root node, allowing a way to specify the system form factor.

The new property is named `chassis-type`, using the same values as systemd's [hostnamed](https://www.freedesktop.org/software/systemd/man/machine-info.html#CHASSIS=).