### PR TITLE
Add SPMI to the list of generic node names

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -273,6 +273,7 @@ name should be one of the following choices:
    * serial
    * sound
    * spi
+   * spmi
    * sram-controller
    * ssi-controller
    * syscon


### PR DESCRIPTION
System Power Management Interface Protocol (SPMI) is a MIPI standard
bus used to connect the Power Management Integrated Circuits (PMIC)
to the SoCs. Let's add "spmi" to the list of generic node names.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>