### PR TITLE
RFC: Allow expressing boolean values with u32

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -375,7 +375,7 @@ sufficiently descriptive.
    ======================== ==================================================================
    ``<empty>``              Value is empty. Used for conveying true-false information, when
                             the presence or absence of the property itself is sufficiently
-                            descriptive.
+                            descriptive. See also <u32>.
    ``<u32>``                A 32-bit integer in big-endian format. Example: the 32-bit value
                             0x11223344 would be represented in memory as:
 
@@ -385,6 +385,11 @@ sufficiently descriptive.
                                   address+1  22
                                   address+2  33
                                   address+3  44
+
+                            This can be used to convey boolean information, where 0 is false
+                            and any other value is true. This is useful since adding and
+                            removing a property to change a boolean value is inconvenient and
+                            can be obscure, since a missing property is obviously not visible.
    ``<u64>``                Represents a 64-bit integer in big-endian format. Consists of
                             two ``<u32>`` values where the first value contains the most
                             significant bits of the integer and the second value contains


### PR DESCRIPTION
This has been on my mind ever since I started using device tree 10 years
ago, so I thought it might be time to send a patch, now that we have a
living specification for device tree.

The current way of expressing boolean values is cute, but it does have
some drawbacks in practice:

Firstly, changing the value requires adding or removing properties, not
just changing the property's value, as is possible with other types. This
means that the device tree size may need to change. In the worst case the
entire device tree may need to be expanded and relocated just to change
one value.

Secondly, when the value is false, it is absent and there is no sign that
it is even a valid property for the node. Of course one can reference the
schema to find out, but in many cases it is nice to show the available
options for easy editing or documentation.

Thirdly, it is much more efficient to change a value than to add/remove a
property, particularly in contrained environments such as boot loaders,
where a flat tree may be in use.

Fourthly, it creates confusion, since boolean values are a special case
in every project that uses device tree.

The intent here is not to require all 'false' properties to be added with
a zero value, just to make that an option.

With this change a property is false if:

   - it is not present [current behaviour]; or
   - it is present, has size 4 and value 0.

A property is considered true if it is present and either:

   - has no value [current behaviour]; or
   - has size other than 4; or
   - has size 4 and non-zero value.

This is backwards-compatible with how booleans currently work, in that no existing device tree files need to change.

By way of example, the current implementation in Linux v5.16 is:

static inline bool of_property_read_bool(const struct device_node *np,
					 const char *propname)
{
	struct property *prop = of_find_property(np, propname, NULL);

	return prop ? true : false;
}

With this change it could be updated to something like this:

static inline bool of_property_read_bool(const struct device_node *np,
					 const char *propname)
{
	int len;
	struct property *prop = of_find_property(np, propname, &len);

	if (!prop || len != sizeof(u32))
		return false;

	return *(u32 *)prop->value ? true : false;
}

The last line could be simplified, if acceptable, by dropping the ternary
expression. It may be desirable to drop the inline nature of this
function also, since the change will increase code size slightly. Note
that it is unnecessary to do the big-endian comparison, but this could be
written using be32_to_cpup() if desired.

IMO this has been a persistent pain point for years, causing confusion and
special cases in various subsystems. Here is a small selection of some
previous discussions/explanations I have found on this topic:

https://lists.ozlabs.org/pipermail/devicetree-discuss/2011-December/010125.html
https://www.spinics.net/lists/devicetree-compiler/msg00925.html
https://patchwork.kernel.org/project/linux-omap/patch/1423159266-25561-2-git-send-email-balbi@ti.com/
https://elinux.org/Device_Tree_Linux#boolean_property
https://www.konsulko.com/yaml-and-device-tree/
https://github.com/jophde/documentation-1/blob/master/configuration/device-tree.md#223-boolean-parameters

I believe the least-worst option here is to change the spec, hence this patch.

Signed-off-by: Simon Glass <sjg@chromium.org>