### PR TITLE
Workaround: Delete problematic edge in interrupt tree example

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -986,7 +986,6 @@ sits in the logical interrupt tree.
       "pci-host" -> "i-pci-host"
       "slot0":e -> "i-slot0":e
       "slot1":e -> "i-slot1":e
-      "device1" -> "i-device1"
       "device2":e -> "i-device2":w
       "device3":e -> "i-device3":e
    }


### PR DESCRIPTION
dot has an issue with edges between two "record" shaped nodes that are
directly on top of each other.  This is reported to occur since 2.40
of graphviz.

In v0.3 this device1 -> i-device1 edge was not drawn either but now this
error causes the whole diagram to be missing from the output.

Until dot is fixed or a better work around is found, delete the problematic
edge.  This gets us back to the v0.3 state.

Closes #56 

Signed-off-by: Bill Mills <bill.mills@linaro.org>