### PR TITLE
Add 'dma-noncoherent' property as a standard property

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -832,6 +832,19 @@ Description:
    coherent DMA operations. Some architectures have coherent DMA by default
    and this property is not applicable.
 
+dma-noncoherent
+~~~~~~~~~~~~
+
+Property name: ``dma-noncoherent``
+
+Value type: ``<empty>``
+
+Description:
+   For architectures which are by default coherent for I/O, the
+   *dma-noncoherent* property is used to indicate a device is not capable of
+   coherent DMA operations. Some architectures have non-coherent DMA by
+   default and this property is not applicable.
+
 name (deprecated)
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Similar to the 'dma-coherent' property, some architectures may be coherent
by default with some devices being non-coherent. Add a property for this
case tool.

Signed-off-by: Heiko Stuebner <heiko@sntech.de>