### PR TITLE
Add UFS Host Controller to the list of generic node names

### DIFF
--- a/source/chapter2-devicetree-basics.rst
+++ b/source/chapter2-devicetree-basics.rst
@@ -292,6 +292,7 @@ name should be one of the following choices:
    * timer
    * touchscreen
    * tpm
+   * ufshc
    * usb
    * usb-hub
    * usb-phy


### PR DESCRIPTION
UFS Host Controller (ufshc) is reponsible for managing the interface between host SW stack and UFS device.

In a lot of places, 'ufs' is used as the node name to identify the host controller, but it is wrong since 'ufs' denotes 'UFS device'.