### PR TITLE
Add 'television' chassis type

### DIFF
--- a/source/chapter3-devicenodes.rst
+++ b/source/chapter3-devicenodes.rst
@@ -63,6 +63,7 @@ are descendants. The full path to the root node is ``/``.
                                                * ``"handset"``
                                                * ``"watch"``
                                                * ``"embedded"``
+                                               * ``"television"``
    Usage legend: R=Required, O=Optional, OR=Optional but Recommended, SD=See Definition
    ===========================================================================================
 


### PR DESCRIPTION
The 'television' chassis type includes Smart TVs and set-top boxes, or any remote-controlled displays in general.

---
Hi,
I plan to use this chassis type in version 2 of the patches to add [initial device trees for Apple A7-A11 SoC based devices](https://lore.kernel.org/asahi/20240911084353.28888-2-towinchenmi@gmail.com/),
which includes Apple TV.

Nick Chan