### PR TITLE
Add 'spectacles' chassis type

### DIFF
--- a/source/chapter3-devicenodes.rst
+++ b/source/chapter3-devicenodes.rst
@@ -64,6 +64,7 @@ are descendants. The full path to the root node is ``/``.
                                                * ``"watch"``
                                                * ``"embedded"``
                                                * ``"television"``
+                                               * ``"spectacles"``
    Usage legend: R=Required, O=Optional, OR=Optional but Recommended, SD=See Definition
    ===========================================================================================
 


### PR DESCRIPTION
With the growing interest in the AR/VR/XR devices, it is expected that more and more devices will have the spectacles or eyeglasses-like form factor. Allow documenting such devices by specifying the 'spectacles' chassis-type.