### PR TITLE
Add "all-in-one" chassis-type

### DIFF
--- a/source/chapter3-devicenodes.rst
+++ b/source/chapter3-devicenodes.rst
@@ -59,6 +59,7 @@ are descendants. The full path to the root node is ``/``.
                                                * ``"laptop"``
                                                * ``"convertible"``
                                                * ``"server"``
+                                               * ``"all-in-one"``
                                                * ``"tablet"``
                                                * ``"handset"``
                                                * ``"watch"``


### PR DESCRIPTION
All in One PCs are desktop computers with integrated display. The Linux kernel contains device trees for Apple silicon iMacs [0] which are best described by this chassis-type.
The SMBIOS specification [1] specifies "All in One" as `0Dh` in "Table 17 – System Enclosure or Chassis Types" as well.

[0] arch/arm64/boot/dts/apple/t8103-j45[67].dts
[1] https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.8.0.pdf